### PR TITLE
Update Get-ExchangeVersion.ps1

### DIFF
--- a/Get-ExchangeVersion.ps1
+++ b/Get-ExchangeVersion.ps1
@@ -96,22 +96,24 @@ Begin {
 		$MainKey= 'SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\{0}\' -f $prodguid
 
 		$displayVersion= $reg.OpenSubKey( ('{0}\InstallProperties' -f $MainKey)).GetValue( 'DisplayVersion')
-		$maxMajor= [regex]::match( $displayVersion, '^\d{1,4}\.\d{1,4}').value
-		$maxMinor= [regex]::match( $displayVersion, '\d{1,4}\.\d{1,4}$').value
-		$updates= $reg.OpenSubKey( ('{0}\Patches' -f $MainKey)).GetSubKeyNames()
+		$maxMajor = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[1].value
+		$maxMinor = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[2].value
+		$maxBuild = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[3].value
+        $maxRevision = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[4].value
+		$updates = $reg.OpenSubKey( ('{0}\Patches' -f $MainKey)).GetSubKeyNames()
 		If( $Updates) {
 			ForEach ($updatekey in $updates) {
-				$update= $reg.OpenSubKey( ('{0}\Patches\{1}' -f $MainKey, $updatekey)).GetValue( 'DisplayName')
-				$fullversion= [regex]::match( $update, '[0-9\.]*$').value
-				$major= [regex]::match( $fullversion, '^\d{1,3}\.\d{1,3}').value
-				$minor= [regex]::match( $fullversion, '\d{1,3}\.\d{1,3}$').value
-				If ($major -gt $maxMajor -or $major -ge $maxMajor -and $minor -gt $maxMinor) {
-					$maxMajor= $major
-					$maxMinor= $minor
+				$update = $reg.OpenSubKey( ('{0}\Patches\{1}' -f $MainKey, $updatekey)).GetValue( 'DisplayName')
+				$fullversion = [regex]::match( $update, '[0-9\.]*$').value
+				[Uint32]$build = [regex]::match( $fullversion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[3].value
+                [Uint32]$revision = [regex]::match( $fullversion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[4].value
+				If ($build -gt $maxBuild -or $build -ge $maxBuild -and $revision -gt $maxRevision) {
+					$maxBuild = $build
+					$maxRevision = $revision
 				}
 			}
 		}
-		return ('{0}.{1}' -f $maxMajor, $maxMinor)
+		return ('{0}.{1}.{2}.{3}' -f $maxMajor, $maxMinor, $maxBuild, $maxRevision)
     }
 
     If(-not( Get-Command Get-ExchangeServer -ErrorAction SilentlyContinue)) {
@@ -120,7 +122,7 @@ Begin {
 }
 Process {
     If($null -eq $ComputerName) {
-        $ComputerName= -Get-ExchangeServer -Identity $ENV:COMPUTERNAME
+        $ComputerName= Get-ExchangeServer -Identity $ENV:COMPUTERNAME
     }
     $ComputerName | ForEach-Object {
         If( $_.getType().FullName -eq 'Microsoft.Exchange.Data.Directory.Management.ExchangeServer') {

--- a/Get-ExchangeVersion.ps1
+++ b/Get-ExchangeVersion.ps1
@@ -44,15 +44,15 @@
 #>
 #Requires -Version 1.0
 Param(
-    [parameter( Position= 0, Mandatory= $false, ValueFromPipelineByPropertyName= $true)] 
+    [parameter( Position=0, Mandatory=$false, ValueFromPipelineByPropertyName=$true)] 
     [alias('Name')]
     [string[]]$ComputerName
 )
 
 Begin {
     # Scripts doesn't works for these roles and only for indicated versions
-    $NonValidRoles= ( 'ProvisionedServer', 'Edge')
-    $ValidVersions= 8, 14, 15
+    $NonValidRoles = ( 'ProvisionedServer', 'Edge')
+    $ValidVersions = 8, 14, 15
 
     Function getExchVersion {
         Param(
@@ -60,25 +60,25 @@ Begin {
         )
 		switch ( $Server.AdminDisplayVersion.Major) {
 			8 {
-				$prodguid= "461C2B4266EDEF444B864AD6D9E5B613"
+				$prodguid = "461C2B4266EDEF444B864AD6D9E5B613"
 				break
 			}
 			14 {
-				$prodguid= "AE1D439464EB1B8488741FFA028E291C"
+				$prodguid = "AE1D439464EB1B8488741FFA028E291C"
 				break
 			}
 			15 {
 				switch( $Server.AdminDisplayVersion.Minor) {
 					0 {
-						$prodguid= "AE1D439464EB1B8488741FFA028E291C"
+						$prodguid = "AE1D439464EB1B8488741FFA028E291C"
 						break
 					}
 					1 {
-						$prodguid= "442189DC8B9EA5040962A6BED9EC1F1F"
+						$prodguid = "442189DC8B9EA5040962A6BED9EC1F1F"
 						break
 					}
 					2 {
-						$prodguid= "442189DC8B9EA5040962A6BED9EC1F1F"
+						$prodguid = "442189DC8B9EA5040962A6BED9EC1F1F"
 						break
 					}
 					default {
@@ -96,17 +96,19 @@ Begin {
 		$MainKey= 'SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\{0}\' -f $prodguid
 
 		$displayVersion= $reg.OpenSubKey( ('{0}\InstallProperties' -f $MainKey)).GetValue( 'DisplayVersion')
-		$maxMajor = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[1].value
-		$maxMinor = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[2].value
-		$maxBuild = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[3].value
-        $maxRevision = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[4].value
+		$exchVersionRegex = [regex]::match( $displayVersion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$')
+		$maxMajor = $exchVersionRegex.captures.groups[1].value
+		$maxMinor = $exchVersionRegex.captures.groups[2].value
+		$maxBuild = $exchVersionRegex.captures.groups[3].value
+		$maxRevision = $exchVersionRegex.captures.groups[4].value
 		$updates = $reg.OpenSubKey( ('{0}\Patches' -f $MainKey)).GetSubKeyNames()
 		If( $Updates) {
 			ForEach ($updatekey in $updates) {
 				$update = $reg.OpenSubKey( ('{0}\Patches\{1}' -f $MainKey, $updatekey)).GetValue( 'DisplayName')
 				$fullversion = [regex]::match( $update, '[0-9\.]*$').value
-				[Uint32]$build = [regex]::match( $fullversion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[3].value
-                [Uint32]$revision = [regex]::match( $fullversion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$').captures.groups[4].value
+				$exchPatchVersionRegex = [regex]::match( $fullversion, '^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?(\d+)$')
+				[Uint32]$build = $exchPatchVersionRegex.captures.groups[3].value
+				[Uint32]$revision = $exchPatchVersionRegex.captures.groups[4].value
 				If ($build -gt $maxBuild -or $build -ge $maxBuild -and $revision -gt $maxRevision) {
 					$maxBuild = $build
 					$maxRevision = $revision
@@ -122,7 +124,7 @@ Begin {
 }
 Process {
     If($null -eq $ComputerName) {
-        $ComputerName= Get-ExchangeServer -Identity $ENV:COMPUTERNAME
+        $ComputerName = Get-ExchangeServer -Identity $ENV:COMPUTERNAME
     }
     $ComputerName | ForEach-Object {
         If( $_.getType().FullName -eq 'Microsoft.Exchange.Data.Directory.Management.ExchangeServer') {
@@ -147,12 +149,12 @@ Process {
 
 	$bOnline= Test-Connection $ThisServer.Name -Count 1 -ErrorAction SilentlyContinue
 
-	$outObj= New-Object Object
+	$outObj = New-Object Object
 	$outObj | Add-Member -MemberType NoteProperty Server $ThisServer.Name
 	If( $bValid -and $bOnline) {
 		$outObj | Add-Member -MemberType NoteProperty Accessible $true
 		$outObj | Add-Member -MemberType NoteProperty AdminVersion $ThisServer.AdminDisplayVersion
-		$exVer= getExchVersion -Server $ThisServer
+		$exVer = getExchVersion -Server $ThisServer
 		$outObj | Add-Member -MemberType NoteProperty ExchangeVersion $exVer
 	}
 	Else {


### PR DESCRIPTION
Fixed broken regex that was not comparing numbers correctly. i.e. Exchange 2013 15.0.1497.6 was deemed higher than 15.0.1497.12 with current methods in the script. Fixed bad cmdlet parameter (-Get...).